### PR TITLE
Move layer routing functions to abstract class

### DIFF
--- a/src/main/java/com/conveyal/r5/streets/EdgeStore.java
+++ b/src/main/java/com/conveyal/r5/streets/EdgeStore.java
@@ -191,7 +191,7 @@ public class EdgeStore implements Serializable {
     public List<CostField> costFields;
 
     /** The street layer of a transport network that the edges in this edgestore make up. */
-    public StreetLayer layer;
+    public RoutableStreetLayer layer;
 
     /** As a convenience, the set of all edge flags that control which modes can traverse the edge */
     public static final transient EnumSet<EdgeFlag> PERMISSION_FLAGS = EnumSet
@@ -204,7 +204,7 @@ public class EdgeStore implements Serializable {
      */
     private long generatedOSMID = 1;
 
-    public EdgeStore (VertexStore vertexStore, StreetLayer layer, int initialSize) {
+    public EdgeStore (VertexStore vertexStore, RoutableStreetLayer layer, int initialSize) {
         this.vertexStore = vertexStore;
         this.layer = layer;
 

--- a/src/main/java/com/conveyal/r5/streets/RoutableStreetLayer.java
+++ b/src/main/java/com/conveyal/r5/streets/RoutableStreetLayer.java
@@ -1,0 +1,91 @@
+package com.conveyal.r5.streets;
+
+import com.conveyal.r5.profile.StreetMode;
+import com.conveyal.r5.transit.TransportNetwork;
+import gnu.trove.list.TIntList;
+import gnu.trove.set.TIntSet;
+import org.locationtech.jts.geom.Envelope;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class RoutableStreetLayer {
+    /**
+     * The radius of a circle in meters within which to search for nearby streets.
+     * This should not necessarily be a constant, but even if it's made settable it should be stored in a field on this
+     * class to avoid cluttering method signatures. Generally you'd set this once at startup and always use the same
+     * value afterward.
+     * 1.6km is really far to walk off a street. But some places have offices in the middle of big parking lots.
+     */
+    public static final double LINK_RADIUS_METERS = 1600;
+
+    /**
+     * Searching for streets takes a fair amount of computation, and the number of streets examined grows roughly as
+     * the square of the radius. In most cases, the closest street is close to the search center point. If the specified
+     * search radius exceeds this value, a mini-search will first be conducted to check for close-by streets before
+     * examining every street within the full specified search radius.
+     */
+    public static final int INITIAL_LINK_RADIUS_METERS = 300;
+
+    // Initialize these when we have an estimate of the number of expected edges.
+    public VertexStore vertexStore = new VertexStore(100_000);
+    public EdgeStore edgeStore = new EdgeStore(vertexStore, this, 200_000);
+
+    // Edge lists should be constructed after the fact from edges. This minimizes serialized size too.
+    public transient List<TIntList> outgoingEdges;
+    public transient List<TIntList> incomingEdges;
+
+    /**
+     * Turn restrictions can potentially affect (include) several edges, so they are stored here and referenced
+     * by index within all edges that are affected by them. TODO what if an edge is affected by multiple restrictions?
+     */
+    public List<TurnRestriction> turnRestrictions = new ArrayList<>();
+
+    /**
+     * The TransportNetwork containing this StreetLayer. This link up the object tree also allows us to access the
+     * TransitLayer associated with this StreetLayer of the same TransportNetwork without maintaining bidirectional
+     * references between the two layers.
+     */
+    public TransportNetwork parentNetwork = null;
+
+    /** A spatial index of all street network edges, using fixed-point WGS84 coordinates. */
+    public transient IntHashGrid spatialIndex = new IntHashGrid();
+
+    /**
+     * Spatial index of temporary edges from a scenario. We used to not have this, and we used to return all
+     * temporarily added edges in every spatial index query (because spatial indexes are allowed to over-select, and
+     * are filtered). However, we now create scenarios with thousands of temporary edges (from thousands of added
+     * transit stops), so we keep two spatial indexes, one for the baseline network and one for the scenario additions.
+     */
+    protected transient IntHashGrid temporaryEdgeIndex;
+
+    public Split findSplit(double lat, double lon, double radiusMeters, StreetMode streetMode) {
+        Split split = null;
+        // If the specified radius is large, first try a mini-search on the assumption
+        // that most linking points are close to roads.
+        if (radiusMeters > INITIAL_LINK_RADIUS_METERS) {
+            split = Split.find(lat, lon, INITIAL_LINK_RADIUS_METERS, this, streetMode);
+        }
+        // If no split point was found by the first search (or no search was yet conducted) search with the full radius.
+        if (split == null) {
+            split = Split.find(lat, lon, radiusMeters, this, streetMode);
+        }
+        return split;
+    }
+
+    public TIntSet findEdgesInEnvelope (Envelope envelope) {
+        TIntSet candidates = spatialIndex.query(envelope);
+        // Include temporary edges
+        if (temporaryEdgeIndex != null) {
+            TIntSet temporaryCandidates = temporaryEdgeIndex.query(envelope);
+            candidates.addAll(temporaryCandidates);
+        }
+
+        // Remove any edges that were temporarily deleted in a scenario.
+        // This allows properly re-splitting the same edge in multiple places.
+        if (edgeStore.temporarilyDeletedEdges != null) {
+            candidates.removeAll(edgeStore.temporarilyDeletedEdges);
+        }
+        return candidates;
+    }
+}

--- a/src/main/java/com/conveyal/r5/streets/Split.java
+++ b/src/main/java/com/conveyal/r5/streets/Split.java
@@ -68,7 +68,7 @@ public class Split {
      * Find a location on an existing street near the given point, without actually creating any vertices or edges.
      * @return a new Split object, or null if no edge was found in range.
      */
-    public static Split find (double lat, double lon, double searchRadiusMeters, StreetLayer streetLayer,
+    public static Split find (double lat, double lon, double searchRadiusMeters, RoutableStreetLayer streetLayer,
                               StreetMode streetMode) {
 
         // After this conversion, the entire geometric calculation is happening in fixed precision int degrees.

--- a/src/main/java/com/conveyal/r5/streets/StreetLayer.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetLayer.java
@@ -74,7 +74,7 @@ import static com.conveyal.r5.streets.VertexStore.VertexFlag.TRAFFIC_SIGNAL;
  * or multidimensional scaling, analagous to force-directed graph layout. http://ceur-ws.org/Vol-733/paper_pacher.pdf
  * You could do something similar using their geographic coordinates (Morton-code-sort the vertices).
  */
-public class StreetLayer implements Serializable, Cloneable {
+public class StreetLayer extends RoutableStreetLayer implements Serializable, Cloneable {
 
     private static final Logger LOG = LoggerFactory.getLogger(StreetLayer.class);
 
@@ -94,38 +94,6 @@ public class StreetLayer implements Serializable, Cloneable {
      * return that existing endpoint.
      */
     private static final int SNAP_RADIUS_MM = 5 * 1000;
-
-    /**
-     * The radius of a circle in meters within which to search for nearby streets.
-     * This should not necessarily be a constant, but even if it's made settable it should be stored in a field on this
-     * class to avoid cluttering method signatures. Generally you'd set this once at startup and always use the same
-     * value afterward.
-     * 1.6km is really far to walk off a street. But some places have offices in the middle of big parking lots.
-     */
-    public static final double LINK_RADIUS_METERS = 1600;
-
-    /**
-     * Searching for streets takes a fair amount of computation, and the number of streets examined grows roughly as
-     * the square of the radius. In most cases, the closest street is close to the search center point. If the specified
-     * search radius exceeds this value, a mini-search will first be conducted to check for close-by streets before
-     * examining every street within the full specified search radius.
-     */
-    public static final int INITIAL_LINK_RADIUS_METERS = 300;
-
-    // Edge lists should be constructed after the fact from edges. This minimizes serialized size too.
-    public transient List<TIntList> outgoingEdges;
-    public transient List<TIntList> incomingEdges;
-
-    /** A spatial index of all street network edges, using fixed-point WGS84 coordinates. */
-    public transient IntHashGrid spatialIndex = new IntHashGrid();
-
-    /**
-     * Spatial index of temporary edges from a scenario. We used to not have this, and we used to return all
-     * temporarily added edges in every spatial index query (because spatial indexes are allowed to over-select, and
-     * are filtered). However, we now create scenarios with thousands of temporary edges (from thousands of added
-     * transit stops), so we keep two spatial indexes, one for the baseline network and one for the scenario additions.
-     */
-    private transient IntHashGrid temporaryEdgeIndex;
 
     // Key is street vertex index, value is BikeRentalStation (with name, number of bikes, spaces id etc.)
     public TIntObjectMap<BikeRentalStation> bikeRentalStationMap;
@@ -153,24 +121,6 @@ public class StreetLayer implements Serializable, Cloneable {
      * behave properly for turn restriction purposes.
      */
     TLongIntMap vertexIndexForOsmNode = new TLongIntHashMap(100_000, 0.75f, -1, -1);
-
-    // Initialize these when we have an estimate of the number of expected edges.
-    public VertexStore vertexStore = new VertexStore(100_000);
-    public EdgeStore edgeStore = new EdgeStore(vertexStore, this, 200_000);
-
-    /**
-     * Turn restrictions can potentially affect (include) several edges, so they are stored here and referenced
-     * by index within all edges that are affected by them. TODO what if an edge is affected by multiple restrictions?
-     */
-    public List<TurnRestriction> turnRestrictions = new ArrayList<>();
-
-    /**
-     * The TransportNetwork containing this StreetLayer. This link up the object tree also allows us to access the
-     * TransitLayer associated with this StreetLayer of the same TransportNetwork without maintaining bidirectional
-     * references between the two layers.
-     */
-    public TransportNetwork parentNetwork = null;
-
 
     /**
      * A string uniquely identifying the contents of this StreetLayer among all StreetLayers.
@@ -1229,21 +1179,6 @@ public class StreetLayer implements Serializable, Cloneable {
      *
      * @param envelope FIXME IN WHAT UNITS, FIXED OR FLOATING?
      */
-    public TIntSet findEdgesInEnvelope (Envelope envelope) {
-        TIntSet candidates = spatialIndex.query(envelope);
-        // Include temporary edges
-        if (temporaryEdgeIndex != null) {
-            TIntSet temporaryCandidates = temporaryEdgeIndex.query(envelope);
-            candidates.addAll(temporaryCandidates);
-        }
-
-        // Remove any edges that were temporarily deleted in a scenario.
-        // This allows properly re-splitting the same edge in multiple places.
-        if (edgeStore.temporarilyDeletedEdges != null) {
-            candidates.removeAll(edgeStore.temporarilyDeletedEdges);
-        }
-        return candidates;
-    }
 
     /**
      * The edge lists (which edges go out of and come into each vertex) are derived from the edges in the EdgeStore.
@@ -1464,19 +1399,6 @@ public class StreetLayer implements Serializable, Cloneable {
      * @return a Split object representing a point along a sub-segment of a specific edge, or null if there are no
      *         streets nearby allowing the specified mode of travel.
      */
-    public Split findSplit(double lat, double lon, double radiusMeters, StreetMode streetMode) {
-        Split split = null;
-        // If the specified radius is large, first try a mini-search on the assumption
-        // that most linking points are close to roads.
-        if (radiusMeters > INITIAL_LINK_RADIUS_METERS) {
-            split = Split.find(lat, lon, INITIAL_LINK_RADIUS_METERS, this, streetMode);
-        }
-        // If no split point was found by the first search (or no search was yet conducted) search with the full radius.
-        if (split == null) {
-            split = Split.find(lat, lon, radiusMeters, this, streetMode);
-        }
-        return split;
-    }
 
     /**
      * For every stop in a TransitLayer, find or create a nearby vertex in the street layer and record the connection


### PR DESCRIPTION
First draft of separating the routing functions of` StreetLayer` from the OSM-based network building functions. The idea is that old `StreetLayer` becomes `OSMStreetLayer`, and other implementations can extend `RoutableStreetLayer` to provide a routable network layer built from non-OSM sources.

Some initial questions/thoughts:
  - Is this a reasonable approach at all?
  - Is this better implemented as an interface?
  - Should `serializable`, `clonable` be required or left up to implementations?
  - Interaction with `Scenario` system will add complication... lots? little? Let scenario support in subclasses be optional?
  - In the long run, is there a potential use for `TransportNetwork` containing multiple `RoutableStreetLayer`? Like one layer built for bike/ped routing, and one for auto routing?
