### PR TITLE
Add PLTS columns for edges and vertices

### DIFF
--- a/src/main/java/com/conveyal/r5/streets/EdgeStore.java
+++ b/src/main/java/com/conveyal/r5/streets/EdgeStore.java
@@ -92,6 +92,9 @@ public class EdgeStore implements Serializable {
     /** Boolean flags for every edge. Separate entries for forward and backward edges. */
     public TIntList flags;
 
+    /** PLTS values for every edge. */
+    public TShortList pltsValues;
+
     /**
      * CAR speeds, one speed for each edge. Separate entries for forward and backward edges.
      * rounded (m/s * 100) (2 decimal places)
@@ -211,6 +214,7 @@ public class EdgeStore implements Serializable {
         // There are separate flags and speeds entries for the forward and backward edges in each pair.
         flags = new TIntArrayList(initialSize);
         speeds = new TShortArrayList(initialSize);
+        pltsValues = new TShortArrayList(initialSize);
         // Vertex indices, geometries, and lengths are shared between pairs of forward and backward edges.
         int initialEdgePairs = initialSize / 2;
         fromVertices = new TIntArrayList(initialEdgePairs);
@@ -369,11 +373,13 @@ public class EdgeStore implements Serializable {
         // No speed or flags are set, they must be set afterward using the edge cursor.
         speeds.add(DEFAULT_SPEED_KPH);
         flags.add(0);
+        pltsValues.add(Short.MAX_VALUE);
 
         // Backward edge.
         // No speed or flags are set, they must be set afterward using the edge cursor.
         speeds.add(DEFAULT_SPEED_KPH);
         flags.add(0);
+        pltsValues.add(Short.MAX_VALUE);
 
         if (edgeTraversalTimes != null) {
             edgeTraversalTimes.addOneNeutralEdge();
@@ -526,6 +532,10 @@ public class EdgeStore implements Serializable {
             return speeds.get(edgeIndex);
         }
 
+        public short getPLTS() {
+            return pltsValues.get(edgeIndex);
+        }
+
         /**
          * @return the car speed on this edge, taking live traffic updates into account if requested (though that's not
          * yet implemented)
@@ -546,6 +556,10 @@ public class EdgeStore implements Serializable {
         /** Note, this is expecting weird units and should be hidden. Use setSpeedKph. */
         public void setSpeed(short speed) {
             speeds.set(edgeIndex, speed);
+        }
+
+        public void setPLTS(short plts) {
+            pltsValues.set(edgeIndex, plts);
         }
 
         public int getLengthMm () {

--- a/src/main/java/com/conveyal/r5/streets/EdgeStore.java
+++ b/src/main/java/com/conveyal/r5/streets/EdgeStore.java
@@ -93,7 +93,7 @@ public class EdgeStore implements Serializable {
     public TIntList flags;
 
     /** PLTS values for every edge. */
-    public TShortList pltsValues;
+    public TByteList pltsValues;
 
     /**
      * CAR speeds, one speed for each edge. Separate entries for forward and backward edges.
@@ -214,7 +214,7 @@ public class EdgeStore implements Serializable {
         // There are separate flags and speeds entries for the forward and backward edges in each pair.
         flags = new TIntArrayList(initialSize);
         speeds = new TShortArrayList(initialSize);
-        pltsValues = new TShortArrayList(initialSize);
+        pltsValues = new TByteArrayList(initialSize);
         // Vertex indices, geometries, and lengths are shared between pairs of forward and backward edges.
         int initialEdgePairs = initialSize / 2;
         fromVertices = new TIntArrayList(initialEdgePairs);
@@ -373,13 +373,13 @@ public class EdgeStore implements Serializable {
         // No speed or flags are set, they must be set afterward using the edge cursor.
         speeds.add(DEFAULT_SPEED_KPH);
         flags.add(0);
-        pltsValues.add(Short.MAX_VALUE);
+        pltsValues.add(Byte.MAX_VALUE);
 
         // Backward edge.
         // No speed or flags are set, they must be set afterward using the edge cursor.
         speeds.add(DEFAULT_SPEED_KPH);
         flags.add(0);
-        pltsValues.add(Short.MAX_VALUE);
+        pltsValues.add(Byte.MAX_VALUE);
 
         if (edgeTraversalTimes != null) {
             edgeTraversalTimes.addOneNeutralEdge();
@@ -532,7 +532,7 @@ public class EdgeStore implements Serializable {
             return speeds.get(edgeIndex);
         }
 
-        public short getPLTS() {
+        public byte getPLTS() {
             return pltsValues.get(edgeIndex);
         }
 
@@ -558,7 +558,7 @@ public class EdgeStore implements Serializable {
             speeds.set(edgeIndex, speed);
         }
 
-        public void setPLTS(short plts) {
+        public void setPLTS(byte plts) {
             pltsValues.set(edgeIndex, plts);
         }
 

--- a/src/main/java/com/conveyal/r5/streets/VertexStore.java
+++ b/src/main/java/com/conveyal/r5/streets/VertexStore.java
@@ -61,7 +61,7 @@ public class VertexStore implements Serializable {
         fixedLats.add(fixedLat);
         fixedLons.add(fixedLon);
         vertexFlags.add((byte)0);
-        pltsValues.add(Short.MAX_VALUE);
+        pltsValues.add(Byte.MAX_VALUE);
         return vertexIndex;
     }
 
@@ -96,7 +96,7 @@ public class VertexStore implements Serializable {
             fixedLons.set(index, (int) (lon * FIXED_FACTOR));
         }
 
-        public void setPLTS(short plts) {
+        public void setPLTS(byte plts) {
             pltsValues.set(index, plts);
         }
 
@@ -124,7 +124,7 @@ public class VertexStore implements Serializable {
             return fixedLons.get(index);
         }
 
-        public short getPLTS() {
+        public byte getPLTS() {
             return pltsValues.get(index);
         }
 

--- a/src/main/java/com/conveyal/r5/streets/VertexStore.java
+++ b/src/main/java/com/conveyal/r5/streets/VertexStore.java
@@ -33,11 +33,13 @@ public class VertexStore implements Serializable {
     public TIntList fixedLats;
     public TIntList fixedLons;
     public TByteList vertexFlags;
+    public TByteList pltsValues;
 
     public VertexStore (int initialSize) {
         fixedLats = new TIntArrayList(initialSize);
         fixedLons = new TIntArrayList(initialSize);
         vertexFlags = new TByteArrayList(initialSize);
+        pltsValues = new TByteArrayList(initialSize);
     }
 
     /**
@@ -59,6 +61,7 @@ public class VertexStore implements Serializable {
         fixedLats.add(fixedLat);
         fixedLons.add(fixedLon);
         vertexFlags.add((byte)0);
+        pltsValues.add(Short.MAX_VALUE);
         return vertexIndex;
     }
 
@@ -93,6 +96,10 @@ public class VertexStore implements Serializable {
             fixedLons.set(index, (int) (lon * FIXED_FACTOR));
         }
 
+        public void setPLTS(short plts) {
+            pltsValues.set(index, plts);
+        }
+
         public boolean getFlag(VertexFlag flag) {
             return VertexStore.this.getFlag(index, flag);
         }
@@ -115,6 +122,10 @@ public class VertexStore implements Serializable {
 
         public int getFixedLon() {
             return fixedLons.get(index);
+        }
+
+        public short getPLTS() {
+            return pltsValues.get(index);
         }
 
         public Point getJTSPointFloating () {


### PR DESCRIPTION
Data structures and access methods for assigning PLTS scores to edges and vertices.

PLTS values are stored as bytes. The default value is Byte.MAX_VALUE (127).

Both EdgeStore and VertexStore both get a new TByteArrayList to store PLTS values. (This is different than the way R5 handles (bike) LTS values, which use 4 bits as flags to indicate LTS values 1, 2, 3 or 4.)