### PR TITLE
Apply PLTS limit during pedestrian routing

### DIFF
--- a/src/main/java/com/conveyal/r5/streets/EdgeStore.java
+++ b/src/main/java/com/conveyal/r5/streets/EdgeStore.java
@@ -673,12 +673,15 @@ public class EdgeStore implements Serializable {
                 return null;
             }
 
-            // Check whether this edge allows the selected mode, considering the request settings.
+// Check whether this edge allows the selected mode, considering the request settings.
             if (streetMode == StreetMode.WALK) {
                 if (!getFlag(EdgeFlag.ALLOWS_PEDESTRIAN)) {
                     return null;
                 }
                 if (req.wheelchair && !getFlag(EdgeFlag.ALLOWS_WHEELCHAIR)) {
+                    return null;
+                }
+                if (this.getPLTS() > req.pedTrafficStress) {
                     return null;
                 }
             } else if (streetMode == StreetMode.BICYCLE) {
@@ -691,6 +694,9 @@ public class EdgeStore implements Serializable {
                 }
                 if (tryWalking) {
                     if (!getFlag(EdgeFlag.ALLOWS_PEDESTRIAN)) {
+                        return null;
+                    }
+                    if (this.getPLTS() > req.pedTrafficStress) {
                         return null;
                     }
                     streetMode = StreetMode.WALK;

--- a/src/main/java/com/conveyal/r5/streets/StreetRouter.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetRouter.java
@@ -587,10 +587,19 @@ public class StreetRouter {
             }
 
             TIntList edgeList;
-            if (profileRequest.reverseSearch) {
-                edgeList = streetLayer.incomingEdges.get(s0.vertex);
+            // For pedestrian routing, allow vertex PLTS value to prevent further routing.
+            // If PLTS limit is exceeded, pretend there are no outgoing edges from the current state vertex.
+            if (s0.streetMode == StreetMode.WALK) {
+                Vertex v = VertexStore.Vertex(s0.vertex);
+                if (v.getPLTS() > profileRequest.pedTrafficStress) {
+                    edgeList = new TIntArrayList(4);
+                }
             } else {
-                edgeList = streetLayer.outgoingEdges.get(s0.vertex);
+                if (profileRequest.reverseSearch) {
+                    edgeList = streetLayer.incomingEdges.get(s0.vertex);
+                } else {
+                    edgeList = streetLayer.outgoingEdges.get(s0.vertex);
+                }
             }
             // explore edges leaving this vertex
             edgeList.forEach(eidx -> {


### PR DESCRIPTION
For edges, `traverse()` returns `null` if PLTS limit is exceeded.

For vertices, show no outgoing edges if PLTS limit is exceeded.