### PR TITLE
Skip barrier processing if StreetNetwork not associated with a TransportNetwork

### DIFF
--- a/src/main/java/com/conveyal/r5/streets/Split.java
+++ b/src/main/java/com/conveyal/r5/streets/Split.java
@@ -125,18 +125,22 @@ public class Split {
                 // Note: the fraction is scaleless, xScale is accounted for in the segmentFraction function.
                 curr.fixedLon = (int)(fixedLon0 + curr.frac * (fixedLon1 - fixedLon0));
                 curr.fixedLat = (int)(fixedLat0 + curr.frac * (fixedLat1 - fixedLat0));
-                // If this candidate link crosses any barriers, move on
-                if (streetLayer.parentNetwork.linkBarrierLayer != null) {
-                    if (streetLayer.parentNetwork.linkBarrierLayer.intersects(fixedLon, fixedLat, curr.fixedLon, curr.fixedLat)) {
-                        System.out.println(
-                            "link," +
-                            "blocked," +
-                            lat + "," +
-                            lon + "," +
-                            VertexStore.fixedDegreesToFloating(curr.fixedLat) + "," +
-                            VertexStore.fixedDegreesToFloating(curr.fixedLon)
-                        );
-                        return;
+
+                // Barrier checking is only available if this StreetLayer is already part of a TransportNetwork
+                if (streetLayer.parentNetwork != null) {
+                    // If this candidate link crosses any barriers, move on
+                    if (streetLayer.parentNetwork.linkBarrierLayer != null) {
+                        if (streetLayer.parentNetwork.linkBarrierLayer.intersects(fixedLon, fixedLat, curr.fixedLon, curr.fixedLat)) {
+                            System.out.println(
+                                    "link," +
+                                            "blocked," +
+                                            lat + "," +
+                                            lon + "," +
+                                            VertexStore.fixedDegreesToFloating(curr.fixedLat) + "," +
+                                            VertexStore.fixedDegreesToFloating(curr.fixedLon)
+                            );
+                            return;
+                        }
                     }
                 }
                 // Find squared distance to edge (avoid taking square root, which is slow)


### PR DESCRIPTION
The barrier-checking process was causing problems during network building because the StreetLayer is not associated with a TransportNetwork (`StreetLayer.parentNetwork` is `null`) until after the network is completely build. So any calls to `Split.find()` would trigger a NPE when trying to reference `parentNetwork.linkBarrierLayer`. In particular, this was happening with transit park-and-ride facilities in OSM when they were processed by `StreetLayer.buildParkAndRideNodes()`.

With this change, the barrier checking code is skipped whenever `StreetLayer.parentNetwork` is `null`.